### PR TITLE
Correct competition typos

### DIFF
--- a/client/src/Components/competitionFilters.js
+++ b/client/src/Components/competitionFilters.js
@@ -1,4 +1,4 @@
-//  all, DSA Competiions, Competative Coding, Hackethrons, Open Source, Development, MNC competiions, Global, Pan India, College Level, MAANG
+//  all, DSA Competitions, Competative Coding, Hackethrons, Open Source, Development, MNC Competitions, Global, Pan India, College Level, MAANG
 
 export const competitionFilters = [
   {
@@ -6,15 +6,15 @@ export const competitionFilters = [
     id: 1,
   },
   {
-    text: "DSA Competiions",
+    text: "DSA Competitions",
     id: 2,
   },
   {
-    text: "Competative Coding",
+    text: "Competitive Coding",
     id: 3,
   },
   {
-    text: "Hackethrons",
+    text: "Hackathons",
     id: 4,
   },
   {
@@ -26,7 +26,7 @@ export const competitionFilters = [
     id: 6,
   },
   {
-    text: "MNC competiions",
+    text: "MNC Competitions",
     id: 7,
   },
   {

--- a/client/src/Screen/CodingCompetitions.js
+++ b/client/src/Screen/CodingCompetitions.js
@@ -91,7 +91,7 @@ const CodingCompetitions = () => {
           <div className="message">
             <div className="icon"></div>
             <div className="text">
-              You know about a coding competiion which is not mentioned here.{" "}
+              You know about a coding competition which is not mentioned here.{" "}
               <a href="/">click here</a>
             </div>
           </div>

--- a/client/src/Screen/CodingCompetitions.js
+++ b/client/src/Screen/CodingCompetitions.js
@@ -1,20 +1,20 @@
-import React, { useState, useEffect, CSSProperties } from 'react';
-import styled from 'styled-components';
-import CCRightMenu from '../Components/CCRightMenu';
-import CCHeader from '../Components/CCHeader';
-import LeftMenu from '../Components/LeftMenu';
-import FilterListIcon from '@material-ui/icons/FilterList';
-import InfoIcon from '@material-ui/icons/Info';
-import { LinearProgress } from '@material-ui/core';
-import TimeLeft from '../helpers/TimeLeft';
-import { competitionFilters } from '../Components/competitionFilters';
-import CompetitionItem from '../Components/CompetitionItem';
+import React, { useState, useEffect, CSSProperties } from "react";
+import styled from "styled-components";
+import CCRightMenu from "../Components/CCRightMenu";
+import CCHeader from "../Components/CCHeader";
+import LeftMenu from "../Components/LeftMenu";
+import FilterListIcon from "@material-ui/icons/FilterList";
+import InfoIcon from "@material-ui/icons/Info";
+import { LinearProgress } from "@material-ui/core";
+import TimeLeft from "../helpers/TimeLeft";
+import { competitionFilters } from "../Components/competitionFilters";
+import CompetitionItem from "../Components/CompetitionItem";
 
 const CodingCompetitions = () => {
   const [temp, setTemp] = useState([1]);
   const [waitingForData, setWaitingForData] = useState(true);
   const [list, setList] = useState();
-  const [filter, setFilter] = useState('All');
+  const [filter, setFilter] = useState("All");
 
   useEffect(() => {
     (async () => {
@@ -40,12 +40,12 @@ const CodingCompetitions = () => {
   // }, [third])
 
   const override = {
-    display: 'block',
-    margin: '0 auto',
-    borderColor: 'red',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
+    display: "block",
+    margin: "0 auto",
+    borderColor: "red",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
   };
 
   const handleFilter = (e) => {
@@ -59,7 +59,7 @@ const CodingCompetitions = () => {
           handleFilter(e);
         }}
         key={item.id}
-        className={item.text == filter ? 'filter selected' : 'filter'}
+        className={item.text == filter ? "filter selected" : "filter"}
       >
         {item.text}
       </div>
@@ -79,7 +79,7 @@ const CodingCompetitions = () => {
       </MobContainer>
       <Container>
         <CCHeader />
-        <LeftMenu marked={'all-coding-competitions'} />
+        <LeftMenu marked={"all-coding-competitions"} />
         <div className="cc-middle-content">
           <h1 className="main-heading">All Upcoming Coding Competitions</h1>
           <p className="heading-supporter">
@@ -91,14 +91,14 @@ const CodingCompetitions = () => {
           <div className="message">
             <div className="icon"></div>
             <div className="text">
-              You know about a coding competiion which is not mentioned here.{' '}
+              You know about a coding competiion which is not mentioned here.{" "}
               <a href="/">click here</a>
             </div>
           </div>
           <p className="heading-supporter">
-            Competions like - Google Kickstart, Codeforces, Leetcode, CC,
-            Hackethrons, ICPC, Hackethrons, Microsoft Imagine, Microsoft Engage,
-            Facebook hackecup, TCS Ninja, Uber Hacktag, Hacktoberfest,
+            Competitions like - Google Kickstart, Codeforces, Leetcode, CC,
+            Hackathons, ICPC, Hackathons, Microsoft Imagine, Microsoft Engage,
+            Facebook Hacker Cup, TCS Ninja, Uber Hacktag, Hacktoberfest,
             Girlscript, GSOC, Code jam, Hash Cup.
           </p>
           <Filters>{filters}</Filters>
@@ -107,7 +107,7 @@ const CodingCompetitions = () => {
               <div className="text">By Relevence</div>
               <FilterListIcon />
             </div>
-            <InfoIcon style={{ fill: '#333' }} />
+            <InfoIcon style={{ fill: "#333" }} />
           </Sort>
           <Table>
             <div className="row top-row">
@@ -129,10 +129,10 @@ const CodingCompetitions = () => {
                       TimeLeft(
                         item.competition_date,
                         item.time_start_mins + item.duration_mins
-                      ) !== 'Expired'
+                      ) !== "Expired"
                   )
                   .map((item, index) => {
-                    if (filter == 'All') {
+                    if (filter == "All") {
                       return (
                         <CompetitionItem
                           key={index}


### PR DESCRIPTION
As previously mentioned, fixed a few typos in both the filter tags and in some of the static text.

There are more changes highlighted in the comparison, but they're all moving from ` ' ' ` single quotes to `" "` double quotes, since Prettier (extension) does it automatically on Save. I'll make sure to disable it the next time I work on an issue, completely forgot this time.

![image](https://user-images.githubusercontent.com/73081185/204151639-4f2392cc-5999-4952-9a53-727919233e76.png)
